### PR TITLE
bumped influxdb version to 1.0.2-1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 
 # Attributes for InfluxDB
 
-default['influxdb']['version'] = '1.0.0-1'
+default['influxdb']['version'] = '1.0.2-1'
 default['influxdb']['install_type'] = 'package'
 
 default['influxdb']['download_urls'] = {


### PR DESCRIPTION
version 1.0.0-1 was no longer available for installation

with 1.0.2-1, the chef recipe went through in my test docker container

root@7667fd3e05c8:~/hyperflow-deployment# sudo service influxdb status
influxdb process is running [ OK ]

however, i did not test if the new influxdb version is still compatible with our version of grafana and hyperflow
